### PR TITLE
sets min version for Analytics

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Analytics (3.0.7)
+  - Analytics (3.1.0)
   - Expecta (1.0.5)
   - Flurry-iOS-SDK (7.5.2):
     - Flurry-iOS-SDK/FlurrySDK (= 7.5.2)
   - Flurry-iOS-SDK/FlurrySDK (7.5.2)
   - Segment-Flurry (1.0.1):
-    - Analytics (~> 3.0.0)
+    - Analytics (~> 3.0)
     - Flurry-iOS-SDK (~> 7.5.2)
   - Specta (1.0.5)
 
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
+  Analytics: e530ca7e91be699a23afbc7d8f4a20752b2c45d8
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Flurry-iOS-SDK: 8c87c4eab6008184ad9f63afabd79ec0d109c82e
-  Segment-Flurry: d46a0b037f66817da1d94581e25b2c091ad5fbaf
+  Segment-Flurry: 6904936a673b10daa12661be7dbd9905d51a1cda
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsRequest.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsRequest.m
@@ -6,7 +6,8 @@
 #import "SEGAnalyticsRequest.h"
 
 
-@interface SEGAnalyticsRequest () <NSURLConnectionDataDelegate> {
+@interface SEGAnalyticsRequest () <NSURLConnectionDataDelegate>
+{
     NSMutableData *_responseData;
 }
 

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGBluetooth.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGBluetooth.m
@@ -44,5 +44,4 @@ const NSString *SEGCentralManagerClass = @"CBCentralManager";
 }
 
 - (void)centralManagerDidUpdateState:(id)central {}
-
 @end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
@@ -10,20 +10,24 @@
 #import "SEGAnalyticsUtils.h"
 #import <CoreLocation/CoreLocation.h>
 
-#define LOCATION_STRING_PROPERTY(NAME, PLACEMARK_PROPERTY)                                      \
-    -(NSString *)NAME                                                                           \
-    {                                                                                           \
-        __block NSString *result = nil;                                                         \
-        dispatch_sync(self.syncQueue, ^{ result = self.currentPlacemark.PLACEMARK_PROPERTY; }); \
-        return result;                                                                          \
+#define LOCATION_STRING_PROPERTY(NAME, PLACEMARK_PROPERTY)     \
+    -(NSString *)NAME                                          \
+    {                                                          \
+        __block NSString *result = nil;                        \
+        dispatch_sync(self.syncQueue, ^{                       \
+            result = self.currentPlacemark.PLACEMARK_PROPERTY; \
+        });                                                    \
+        return result;                                         \
     }
 
-#define LOCATION_NUMBER_PROPERTY(NAME, PLACEMARK_PROPERTY)                                         \
-    -(NSNumber *)NAME                                                                              \
-    {                                                                                              \
-        __block NSNumber *result = nil;                                                            \
-        dispatch_sync(self.syncQueue, ^{ result = @(self.currentPlacemark.PLACEMARK_PROPERTY); }); \
-        return result;                                                                             \
+#define LOCATION_NUMBER_PROPERTY(NAME, PLACEMARK_PROPERTY)        \
+    -(NSNumber *)NAME                                             \
+    {                                                             \
+        __block NSNumber *result = nil;                           \
+        dispatch_sync(self.syncQueue, ^{                          \
+            result = @(self.currentPlacemark.PLACEMARK_PROPERTY); \
+        });                                                       \
+        return result;                                            \
     }
 
 #define LOCATION_AGE 300.0 // 5 minutes

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -530,7 +530,7 @@ static BOOL GetAdTrackingEnabled()
 {
     [self dispatchBackgroundAndWait:^{
         if (self.queue.count)
-            
+
             [self persistQueue];
     }];
 }

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
@@ -1,6 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "SEGIntegrationFactory.h"
 
+/**
+ * NSNotification name, that is posted after integrations are loaded.
+ */
+extern NSString *SEGAnalyticsIntegrationDidStart;
+
 @protocol SEGIntegrationFactory;
 
 /**
@@ -36,6 +41,12 @@
  * The number of queued events that the analytics client should flush at. Setting this to `1` will not queue any events and will use more battery. `20` by default.
  */
 @property (nonatomic, assign) NSUInteger flushAt;
+
+
+/**
+ * Whether the analytics client should automatically make a track call for application lifecycle events, such as "Application Installed", "Application Updated" and "Application Opened".
+ */
+@property (nonatomic, assign) BOOL trackApplicationLifecycleEvents;
 
 
 /**

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
@@ -123,12 +123,58 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
                                   UIApplicationDidBecomeActiveNotification ]) {
             [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
         }
+
+        [self trackApplicationLifecycleEvents:configuration.trackApplicationLifecycleEvents];
     }
     return self;
 }
 
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
 #pragma mark - NSNotificationCenter Callback
+NSString *const SEGVersionKey = @"SEGVersionKey";
+NSString *const SEGBuildKey = @"SEGBuildKey";
+
+- (void)trackApplicationLifecycleEvents:(BOOL)trackApplicationLifecycleEvents
+{
+    if (!trackApplicationLifecycleEvents) {
+        return;
+    }
+
+    NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
+    NSInteger previousBuild = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKey];
+
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+    NSInteger currentBuild = [[[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] integerValue];
+
+    if (!previousBuild) {
+        [self track:@"Application Installed" properties:@{
+            @"version" : currentVersion,
+            @"build" : @(currentBuild)
+        }];
+    } else if (currentBuild != previousBuild) {
+        [self track:@"Application Updated" properties:@{
+            @"previous_version" : previousVersion,
+            @"previous_build" : @(previousBuild),
+            @"version" : currentVersion,
+            @"build" : @(currentBuild)
+        }];
+    }
+
+
+    [self track:@"Application Started" properties:@{
+        @"version" : currentVersion,
+        @"build" : @(currentBuild)
+    }];
+
+    [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
+    [[NSUserDefaults standardUserDefaults] setInteger:currentBuild forKey:SEGBuildKey];
+}
 
 
 - (void)onAppForeground:(NSNotification *)note
@@ -143,19 +189,19 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     static dispatch_once_t selectorMappingOnce;
     dispatch_once(&selectorMappingOnce, ^{
         selectorMapping = @{
-                            UIApplicationDidFinishLaunchingNotification :
-                                NSStringFromSelector(@selector(applicationDidFinishLaunching:)),
-                            UIApplicationDidEnterBackgroundNotification :
-                                NSStringFromSelector(@selector(applicationDidEnterBackground)),
-                            UIApplicationWillEnterForegroundNotification :
-                                NSStringFromSelector(@selector(applicationWillEnterForeground)),
-                            UIApplicationWillTerminateNotification :
-                                NSStringFromSelector(@selector(applicationWillTerminate)),
-                            UIApplicationWillResignActiveNotification :
-                                NSStringFromSelector(@selector(applicationWillResignActive)),
-                            UIApplicationDidBecomeActiveNotification :
-                                NSStringFromSelector(@selector(applicationDidBecomeActive))
-                            };
+            UIApplicationDidFinishLaunchingNotification :
+                NSStringFromSelector(@selector(applicationDidFinishLaunching:)),
+            UIApplicationDidEnterBackgroundNotification :
+                NSStringFromSelector(@selector(applicationDidEnterBackground)),
+            UIApplicationWillEnterForegroundNotification :
+                NSStringFromSelector(@selector(applicationWillEnterForeground)),
+            UIApplicationWillTerminateNotification :
+                NSStringFromSelector(@selector(applicationWillTerminate)),
+            UIApplicationWillResignActiveNotification :
+                NSStringFromSelector(@selector(applicationWillResignActive)),
+            UIApplicationDidBecomeActiveNotification :
+                NSStringFromSelector(@selector(applicationDidBecomeActive))
+        };
     });
     SEL selector = NSSelectorFromString(selectorMapping[note.name]);
     if (selector) {
@@ -428,7 +474,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
 + (NSString *)version
 {
-    return @"3.0.7";
+    return @"3.1.0";
 }
 
 #pragma mark - Private

--- a/Example/Pods/Analytics/README.md
+++ b/Example/Pods/Analytics/README.md
@@ -1,6 +1,5 @@
 # Analytics
 
-[![CI Status](https://img.shields.io/travis/segmentio/analytics-ios.svg?style=flat)](https://travis-ci.org/segmentio/analytics-ios)
 [![Version](https://img.shields.io/cocoapods/v/Analytics.svg?style=flat)](https://cocoapods.org//pods/Analytics)
 [![License](https://img.shields.io/cocoapods/l/Analytics.svg?style=flat)](http://cocoapods.org/pods/Analytics)
 

--- a/Example/Pods/Local Podspecs/Segment-Flurry.podspec.json
+++ b/Example/Pods/Local Podspecs/Segment-Flurry.podspec.json
@@ -22,7 +22,7 @@
   "source_files": "Pod/Classes/**/*",
   "dependencies": {
     "Analytics": [
-      "~> 3.0.0"
+      "~> 3.0"
     ],
     "Flurry-iOS-SDK": [
       "~> 7.5.2"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Analytics (3.0.7)
+  - Analytics (3.1.0)
   - Expecta (1.0.5)
   - Flurry-iOS-SDK (7.5.2):
     - Flurry-iOS-SDK/FlurrySDK (= 7.5.2)
   - Flurry-iOS-SDK/FlurrySDK (7.5.2)
   - Segment-Flurry (1.0.1):
-    - Analytics (~> 3.0.0)
+    - Analytics (~> 3.0)
     - Flurry-iOS-SDK (~> 7.5.2)
   - Specta (1.0.5)
 
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
+  Analytics: e530ca7e91be699a23afbc7d8f4a20752b2c45d8
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Flurry-iOS-SDK: 8c87c4eab6008184ad9f63afabd79ec0d109c82e
-  Segment-Flurry: d46a0b037f66817da1d94581e25b2c091ad5fbaf
+  Segment-Flurry: 6904936a673b10daa12661be7dbd9905d51a1cda
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-Flurry.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-Flurry.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'D384A8EC7E968FF398B94764'
+               BlueprintIdentifier = '63BE315F59DDBA4872BEB196'
                BlueprintName = 'Segment-Flurry'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Segment_Flurry.framework'>

--- a/Example/Pods/Target Support Files/Analytics/Info.plist
+++ b/Example/Pods/Target Support Files/Analytics/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.7</string>
+  <string>3.1.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Segment-Flurry.podspec
+++ b/Segment-Flurry.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.0.0'
+  s.dependency 'Analytics', '~> 3.0'
   s.dependency 'Flurry-iOS-SDK', '~> 7.5.2'
 end


### PR DESCRIPTION
when running `pod install` received this error

```
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `Analytics (~> 3.1)` required by `Podfile`
- `Analytics (~> 3.1)` required by `Podfile`
- `Analytics (~> 3.0.0)` required by `Segment-Flurry (1.0.1)`
```

Changing `Analytics (~> 3.0.0)` to `Analytics (~> 3.0)` allows user to have `Analytics` versions 3.0 - < 4.0
