### PR TITLE
remove excess parameters in track and screen

### DIFF
--- a/Pod/Classes/SEGFlurryIntegration.m
+++ b/Pod/Classes/SEGFlurryIntegration.m
@@ -58,7 +58,7 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
-    NSMutableDictionary *properties = [self formatProperties:payload.properties];
+    NSMutableDictionary *properties = [self truncateProperties:payload.properties];
 
     [Flurry logEvent:payload.event withParameters:properties];
     SEGLog(@"Flurry logEvent:%@ withParameters:%@", payload.event, properties);
@@ -68,7 +68,7 @@
 {
     if ([self screenTracksEvents]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
-        NSMutableDictionary *properties = [self formatProperties:payload.properties];
+        NSMutableDictionary *properties = [self truncateProperties:payload.properties];
         [Flurry logEvent:event withParameters:properties];
         SEGLog(@"Flurry logEvent:%@ withParameters:%@", event, properties);
     }
@@ -87,16 +87,16 @@
 
 // Returns NSDictionary truncated to 10 entries
 
--(NSMutableDictionary *)formatProperties:(NSDictionary *) properties
+-(NSMutableDictionary *)truncateProperties:(NSDictionary *) properties
 {
-    NSMutableDictionary *formattedProperties;
+    NSMutableDictionary *truncatedProperties;
     for (NSString *property in properties) {
-        formattedProperties[property] = properties[property];
-        if ([formattedProperties count] == 10) {
+        truncatedProperties[property] = properties[property];
+        if ([truncatedProperties count] == 10) {
             break;
         }
     }
-    return formattedProperties;
+    return truncatedProperties;
 }
 
 @end

--- a/Pod/Classes/SEGFlurryIntegration.m
+++ b/Pod/Classes/SEGFlurryIntegration.m
@@ -58,14 +58,19 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
-    [Flurry logEvent:payload.event withParameters:payload.properties];
+    NSMutableDictionary *properties = [self formatProperties:payload.properties];
+
+    [Flurry logEvent:payload.event withParameters:properties];
+    SEGLog(@"Flurry logEvent:%@ withParameters:%@", payload.event, properties);
 }
 
 - (void)screen:(SEGScreenPayload *)payload
 {
     if ([self screenTracksEvents]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
-        [Flurry logEvent:event withParameters:payload.properties];
+        NSMutableDictionary *properties = [self formatProperties:payload.properties];
+        [Flurry logEvent:event withParameters:properties];
+        SEGLog(@"Flurry logEvent:%@ withParameters:%@", event, properties);
     }
 
     // Flurry just counts the number of page views
@@ -78,6 +83,20 @@
 - (BOOL)screenTracksEvents
 {
     return [(NSNumber *)[self.settings objectForKey:@"screenTracksEvents"] boolValue];
+}
+
+// Returns NSDictionary truncated to 10 entries
+
+-(NSMutableDictionary *)formatProperties:(NSDictionary *) properties
+{
+    NSMutableDictionary *formattedProperties;
+    for (NSString *property in properties) {
+        formattedProperties[property] = properties[property];
+        if ([formattedProperties count] == 10) {
+            break;
+        }
+    }
+    return formattedProperties;
 }
 
 @end


### PR DESCRIPTION
@f2prateek Flurry can only accept a maximum of 10 parameters, any more and the call will be rejected. This PR truncates the properties dict length to a maximum of 10
