### PR TITLE
Fix truncated properties for track event

### DIFF
--- a/Pod/Classes/SEGFlurryIntegration.m
+++ b/Pod/Classes/SEGFlurryIntegration.m
@@ -89,7 +89,7 @@
 
 -(NSMutableDictionary *)truncateProperties:(NSDictionary *) properties
 {
-    NSMutableDictionary *truncatedProperties;
+    NSMutableDictionary *truncatedProperties = [NSMutableDictionary dictionaryWithCapacity:10];
     for (NSString *property in properties) {
         truncatedProperties[property] = properties[property];
         if ([truncatedProperties count] == 10) {


### PR DESCRIPTION
Noticed with our Flurry integration that event properties were not being forwarded. Turned out that the new dictionary for the truncated properties was declared but not initialized so always returned null. 