### PR TITLE
[DEST-1542] Bump flurry sdk to v10.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+Version 2.0.0 *(17th August, 2016)*
+-------------------------------------------
+*(Supports Flury 10.2.0+)*
+
+  * Breaking: Removed support for logPageView
+  * Breaking: Removed support for setLatitude, will no longer track absolute location
+  * Update: Replace setSessionContinueSeconds with withSessionContinueSeconds
+  * Update Flurry SDK requirement.
+
+  Note: Please see [Flurry release notes](https://developer.yahoo.com/flurry/docs/releasenotes/ios/#version-10-2-0-1-08-2020) for complete list of changes.
+
 Version 1.1.0 *(17th August, 2016)*
 -------------------------------------------
 *(Supports analytics-ios 3.0+ and Flury 7.6+)*

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Analytics (3.3.0)
-  - Expecta (1.0.5)
-  - Flurry-iOS-SDK (7.6.6):
-    - Flurry-iOS-SDK/FlurrySDK (= 7.6.6)
-  - Flurry-iOS-SDK/FlurrySDK (7.6.6)
-  - OCHamcrest (5.4.0)
-  - OCMockito (3.0.2):
-    - OCHamcrest (~> 5.1)
-  - Segment-Flurry (1.0.2):
+  - Analytics (3.7.1)
+  - Expecta (1.0.6)
+  - Flurry-iOS-SDK (10.2.0):
+    - Flurry-iOS-SDK/FlurrySDK (= 10.2.0)
+  - Flurry-iOS-SDK/FlurrySDK (10.2.0)
+  - OCHamcrest (7.1.2)
+  - OCMockito (5.1.3):
+    - OCHamcrest (~> 7.0)
+  - Segment-Flurry (1.1.0):
     - Analytics (~> 3.0)
-    - Flurry-iOS-SDK (~> 7.6)
-  - Specta (1.0.5)
+    - Flurry-iOS-SDK (~> 10.2.0)
+  - Specta (1.0.7)
 
 DEPENDENCIES:
   - Expecta
@@ -18,19 +18,28 @@ DEPENDENCIES:
   - Segment-Flurry (from `../`)
   - Specta
 
+SPEC REPOS:
+  trunk:
+    - Analytics
+    - Expecta
+    - Flurry-iOS-SDK
+    - OCHamcrest
+    - OCMockito
+    - Specta
+
 EXTERNAL SOURCES:
   Segment-Flurry:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: be3d952b8b0f21679e25af3b9dfbbab89597e897
-  Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  Flurry-iOS-SDK: 97bbeec09cca666c2f1772f6e161c4f8ccff611e
-  OCHamcrest: 5c1d441c5a82fb18ac17c2aeb52ec1a99edb971b
-  OCMockito: 2cb6c2267cbc76537be56281cd47cdb5a7c27541
-  Segment-Flurry: ca5dcffc60457964b22e05efed8d2b1f1ebfde9c
-  Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
+  Analytics: f82f3cd6d3c8fbfd76ce25773199576656981a4a
+  Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  Flurry-iOS-SDK: ca3540dd9607a05a8a13a7dd36dfffdd5e0fd0ef
+  OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
+  OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
+  Segment-Flurry: 8690bfd728046b9b49252e7ecbabdc4cebdf7979
+  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 724b785d1616828b127cf80906984f5d52080b33
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.8.4

--- a/Example/Segment-Flurry.xcodeproj/project.pbxproj
+++ b/Example/Segment-Flurry.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		B2BC903A75DA2C66E40ACFA5 /* libPods-Segment-Flurry_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Flurry_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5C7F891EC02A0D4A05B53D1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		C7F51CE584117465C1645EA8 /* libPods-Segment-Flurry_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Flurry_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E5E9401B5B048AFC1300D5AE /* Segment-Flurry.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Segment-Flurry.podspec"; path = "../Segment-Flurry.podspec"; sourceTree = "<group>"; };
+		E5E9401B5B048AFC1300D5AE /* Segment-Flurry.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Segment-Flurry.podspec"; path = "../Segment-Flurry.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,8 +204,6 @@
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				8E8021F8E4DA45FB032960C9 /* [CP] Embed Pods Frameworks */,
-				04E1F976BA405E85A3A0C983 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -224,8 +222,6 @@
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				2D9CC1027A24D877A662F17F /* [CP] Embed Pods Frameworks */,
-				9534CFBE79DCC8BDFAC274DA /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -257,6 +253,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -293,79 +290,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		04E1F976BA405E85A3A0C983 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Flurry_Example/Pods-Segment-Flurry_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2D9CC1027A24D877A662F17F /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Flurry_Tests/Pods-Segment-Flurry_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8E8021F8E4DA45FB032960C9 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Flurry_Example/Pods-Segment-Flurry_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9534CFBE79DCC8BDFAC274DA /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Flurry_Tests/Pods-Segment-Flurry_Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		992D32DB2F2180A7AE72CA1F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Flurry_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD2FBB32D181350F635EB269 /* [CP] Check Pods Manifest.lock */ = {
@@ -374,13 +314,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Flurry_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Segment-Flurry/SEGAppDelegate.m
+++ b/Example/Segment-Flurry/SEGAppDelegate.m
@@ -7,12 +7,30 @@
 //
 
 #import "SEGAppDelegate.h"
+#import <Segment-Flurry/SEGFlurryIntegrationFactory.h>
 
 @implementation SEGAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
+    [SEGAnalytics debug:YES];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@""];
+
+    // Add any of your bundled integrations.
+    [config use:[SEGFlurryIntegrationFactory instance]];
+
+    [SEGAnalytics setupWithConfiguration:config];
+
+    [[SEGAnalytics sharedAnalytics] identify:@"segment-fake-tester"
+                                      traits:@{ @"email" : @"tool@fake-segment-tester.com" }];
+
+    [[SEGAnalytics sharedAnalytics] track:@"Completed Order"
+                               properties:@{ @"title" : @"Launch Screen",
+                                             @"revenue" : @14.51 }];
+    
+    [[SEGAnalytics sharedAnalytics] screen:@"Home"];
+    
     return YES;
 }
 

--- a/Pod/Classes/SEGFlurryIntegration.m
+++ b/Pod/Classes/SEGFlurryIntegration.m
@@ -12,16 +12,18 @@
 {
     if (self = [super init]) {
         self.settings = settings;
-
+        
+        FlurrySessionBuilder* builder = [FlurrySessionBuilder new];
+        
         NSNumber *sessionContinueSeconds = settings[@"sessionContinueSeconds"];
         if (sessionContinueSeconds) {
             int s = [sessionContinueSeconds intValue];
-            [Flurry setSessionContinueSeconds:[sessionContinueSeconds intValue]];
+            [builder withSessionContinueSeconds:s];
             SEGLog(@"Flurry setSessionContinueSeconds:%d", s);
         }
 
         NSString *apiKey = self.settings[@"apiKey"];
-        [Flurry startSession:apiKey];
+        [Flurry startSession:apiKey withSessionBuilder:builder];
         SEGLog(@"Flurry startSession:%@", apiKey);
     }
     return self;
@@ -45,15 +47,6 @@
     if (age) {
         [Flurry setAge:[age intValue]];
     }
-
-    NSDictionary *location = traits[@"location"];
-    if (location) {
-        float latitude = [location[@"latitude"] floatValue];
-        float longitude = [location[@"longitude"] floatValue];
-        float horizontalAccuracy = [location[@"horizontalAccuracy"] floatValue];
-        float verticalAccuracy = [location[@"verticalAccuracy"] floatValue];
-        [Flurry setLatitude:latitude longitude:longitude horizontalAccuracy:horizontalAccuracy verticalAccuracy:verticalAccuracy];
-    }
 }
 
 - (void)track:(SEGTrackPayload *)payload
@@ -72,11 +65,6 @@
         [Flurry logEvent:event withParameters:properties];
         SEGLog(@"Flurry logEvent:%@ withParameters:%@", event, properties);
     }
-
-    // Flurry just counts the number of page views
-    // http://stackoverflow.com/questions/5404513/tracking-page-views-with-the-help-of-flurry-sdk
-
-    [Flurry logPageView];
 }
 
 // Return true if all screen should be tracked as event.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWith
 
 ```
 
+## Migrating from 1.1.0 to 2.0.0
+Version 2.0.0 upgrades the Flurry iOS SDK from 7.6 to 10.2.0. Support was removed for logPageView, setLatitude, and setSessionContinueSeconds (replaced by withSessionContinueSeconds). 
+
+Please see [Flurry release notes](https://developer.yahoo.com/flurry/docs/releasenotes/ios/#version-10-2-0-1-08-2020) for complete list of changes.
+
+
 ## License
 
 ```

--- a/Segment-Flurry.podspec
+++ b/Segment-Flurry.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Flurry-iOS-SDK', '~> 7.6'
+  s.dependency 'Flurry-iOS-SDK', '~> 10.2.0'
 end


### PR DESCRIPTION
Bumps the Flurry  iOS SDK to v10.2.0.
`setSessionContinueSeconds`, `setLatitude` were completely removed from the SDK in [version 10.0.0 in September 2019](https://developer.yahoo.com/flurry/docs/releasenotes/ios/#api-removals). v10.0.0 also deprecated `onPageView`, so I've proactively removed it due to the long cadence of releases to this integration, and also [because I'm removing it from the Android integration as well.](https://github.com/segment-integrations/analytics-android-integration-flurry/pull/13)

- Removes `setSessionContinueSeconds` and replaces with the `withSessionContinueSeconds` available when creating a new session with a builder: `FlurrySessionBuilder* builder = [FlurrySessionBuilder new];`
- Removes setting location data due to `setLatitude` removal, does not replace functionality.
- remove `onPageView` and do not replace with new functionality.

Tested track, identify, and screen events:
```
- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{
    // Override point for customization after application launch.
    [SEGAnalytics debug:YES];
    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@""];

    // Add any of your bundled integrations.
    [config use:[SEGFlurryIntegrationFactory instance]];

    [SEGAnalytics setupWithConfiguration:config];

    [[SEGAnalytics sharedAnalytics] identify:@"segment-fake-tester"
                                      traits:@{ @"email" : @"tool@fake-segment-tester.com" }];

    [[SEGAnalytics sharedAnalytics] track:@"Completed Order"
                               properties:@{ @"title" : @"Launch Screen",
                                             @"revenue" : @14.51 }];
    
    [[SEGAnalytics sharedAnalytics] screen:@"Home"];
    
    return YES;
}
```

Outbound request:
```
2020-04-15 14:43:13.299107-0700 Segment-Flurry_Example[73461:4622835] <0x60000080ca20:SEGSegmentIntegration, 03rezq0BAblpgFXUdiCOoPFj0aFpX0EJ> Flushing 3 of 3 queued API calls.
2020-04-15 14:43:13.299741-0700 Segment-Flurry_Example[73461:4622835] Flushing batch {
    batch =     (

// identify
                {
            anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
            context =             {
                app =                 {
                    build = "1.0";
                    name = "Segment-Flurry_Example";
                    namespace = "org.cocoapods.demo.Segment-Flurry-Example";
                    version = "1.0";
                };
                device =                 {
                    id = "2B3659A2-DAD3-4E55-BC07-8A9D6E634CA3";
                    manufacturer = Apple;
                    model = "x86_64";
                    type = ios;
                };
                library =                 {
                    name = "analytics-ios";
                    version = "3.7.1";
                };
                locale = "en-US";
                network =                 {
                    cellular = 0;
                    wifi = 1;
                };
                os =                 {
                    name = iOS;
                    version = "13.4";
                };
                screen =                 {
                    height = 568;
                    width = 320;
                };
                timezone = "America/Los_Angeles";
                traits =                 {
                    anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
                    email = "tool@fake-segment-tester.com";
                    userId = "segment-fake-tester";
                };
            };
            integrations =             {
            };
            messageId = "42F27F82-A6E6-4C2A-9587-86E7D48766ED";
            timestamp = "2020-04-15T21:42:43.298Z";
            traits =             {
                anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
                email = "tool@fake-segment-tester.com";
                userId = "segment-fake-tester";
            };
            type = identify;
            userId = "segment-fake-tester";
        },

// track
                {
            anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
            context =             {
                app =                 {
                    build = "1.0";
                    name = "Segment-Flurry_Example";
                    namespace = "org.cocoapods.demo.Segment-Flurry-Example";
                    version = "1.0";
                };
                device =                 {
                    id = "2B3659A2-DAD3-4E55-BC07-8A9D6E634CA3";
                    manufacturer = Apple;
                    model = "x86_64";
                    type = ios;
                };
                library =                 {
                    name = "analytics-ios";
                    version = "3.7.1";
                };
                locale = "en-US";
                network =                 {
                    cellular = 0;
                    wifi = 1;
                };
                os =                 {
                    name = iOS;
                    version = "13.4";
                };
                screen =                 {
                    height = 568;
                    width = 320;
                };
                timezone = "America/Los_Angeles";
                traits =                 {
                    anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
                    email = "tool@fake-segment-tester.com";
                    userId = "segment-fake-tester";
                };
            };
            event = "Completed Order";
            integrations =             {
            };
            messageId = "A0FEE018-A79F-47DC-9C49-E99B0A1DCBC8";
            properties =             {
                revenue = "14.51";
                title = "Launch Screen";
            };
            timestamp = "2020-04-15T21:42:43.299Z";
            type = track;
            userId = "segment-fake-tester";
        },

// screen
                {
            anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
            context =             {
                app =                 {
                    build = "1.0";
                    name = "Segment-Flurry_Example";
                    namespace = "org.cocoapods.demo.Segment-Flurry-Example";
                    version = "1.0";
                };
                device =                 {
                    id = "2B3659A2-DAD3-4E55-BC07-8A9D6E634CA3";
                    manufacturer = Apple;
                    model = "x86_64";
                    type = ios;
                };
                library =                 {
                    name = "analytics-ios";
                    version = "3.7.1";
                };
                locale = "en-US";
                network =                 {
                    cellular = 0;
                    wifi = 1;
                };
                os =                 {
                    name = iOS;
                    version = "13.4";
                };
                screen =                 {
                    height = 568;
                    width = 320;
                };
                timezone = "America/Los_Angeles";
                traits =                 {
                    anonymousId = "7955948E-DD94-42C4-8863-AD0E0BB1B587";
                    email = "tool@fake-segment-tester.com";
                    userId = "segment-fake-tester";
                };
            };
            integrations =             {
            };
            messageId = "CDFF3766-91C0-4E14-9076-60F5F042DCA4";
            name = Home;
            properties =             {
            };
            timestamp = "2020-04-15T21:42:43.299Z";
            type = screen;
            userId = "segment-fake-tester";
        }
    );
    sentAt = "2020-04-15T21:43:13.299Z";
}.
```